### PR TITLE
Replace all non-alphanumeric for lockup filenames

### DIFF
--- a/src/Service/Core.php
+++ b/src/Service/Core.php
@@ -110,8 +110,8 @@ class Core
     {
         $lockups_name = $lockups->getName();
         $department_name = strtoupper($lockups->getInstitution());
-        $lockups_name = str_replace(" ", "_", $lockups_name);
-        $department_name = str_replace(" ", "_", $department_name);
+        $lockups_name = preg_replace('/[^A-Za-z0-9_\-]+/', '_', $lockups_name);
+        $department_name = preg_replace('/[^A-Za-z0-9_\-]+/', '_', $department_name);
         if (!empty($department_name)) {
             $lockups_name = $department_name . "_" . $lockups_name;
         }


### PR DESCRIPTION
Errors came up when saving files with non-alphanumeric characters in the file name. This change will fix that